### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/swearjar.gemspec
+++ b/swearjar.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
   s.test_files = `git ls-files`.split("\n").select{|f| f =~ /^spec/}
-  s.rubyforge_project = 'swearjar'
 
   # dependencies
   s.add_development_dependency 'rake',    '~> 10.5'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436