### PR TITLE
Update TravisCI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 rvm:
-  - ruby-1.9.3
   - ruby-2.0.0
-  - ruby-2.1
+  - ruby-2.6
   - jruby
 sudo: false

--- a/swearjar.gemspec
+++ b/swearjar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files`.split("\n").select{|f| f =~ /^spec/}
 
   # dependencies
-  s.add_development_dependency 'rake',    '~> 13.0'
+  s.add_development_dependency 'rake',    '>= 12.3.3'
   s.add_development_dependency 'rspec',   '~> 3.9'
   s.add_development_dependency 'pry',   '~> 0.13'
 end


### PR DESCRIPTION
Rolling back the rake development dependency a little bit so TravisCI can test on more Ruby versions.

Removing 1.9.3 from the list because it was deprecated a long time ago.